### PR TITLE
making FLICKR_API_KEY lazy available

### DIFF
--- a/public/js/models/photo.js
+++ b/public/js/models/photo.js
@@ -1,6 +1,6 @@
 YUI.add('pnm-photo', function (Y) {
 
-var FLICKR_API_KEY = YUI.namespace('Env.Flickr').API_KEY || '',
+var FLICKR_API_KEY,
 
     Lang  = Y.Lang,
     Place = Y.PNM.Place,
@@ -14,6 +14,9 @@ Photo = Y.Base.create('photo', Y.Model, [Y.ModelSync.YQL], {
     pageUrl: 'http://www.flickr.com/photos/{user}/{id}/',
 
     buildQuery: function () {
+        // one time initialization for FLICKR_API_KEY in lazy mode
+        FLICKR_API_KEY = FLICKR_API_KEY || YUI.namespace('Env.Flickr').API_KEY || '';
+
         return Lang.sub(this.query, {
             api_key: FLICKR_API_KEY,
             id     : this.get('id'),

--- a/public/js/models/photos.js
+++ b/public/js/models/photos.js
@@ -1,6 +1,6 @@
 YUI.add('pnm-photos', function (Y) {
 
-var FLICKR_API_KEY = YUI.namespace('Env.Flickr').API_KEY || '',
+var FLICKR_API_KEY,
 
     Lang  = Y.Lang,
     Photo = Y.PNM.Photo,
@@ -19,6 +19,9 @@ Photos = Y.Base.create('photos', Y.ModelList, [Y.ModelSync.YQL], {
 
     buildQuery: function (options) {
         options || (options = {});
+
+        // one time initialization for FLICKR_API_KEY in lazy mode
+        FLICKR_API_KEY = FLICKR_API_KEY || YUI.namespace('Env.Flickr').API_KEY || '';
 
         return Lang.sub(this.query, {
             api_key: FLICKR_API_KEY,

--- a/public/js/models/place.js
+++ b/public/js/models/place.js
@@ -1,6 +1,6 @@
 YUI.add('pnm-place', function (Y) {
 
-var FLICKR_API_KEY = YUI.namespace('Env.Flickr').API_KEY || '',
+var FLICKR_API_KEY,
 
     Lang = Y.Lang,
     Place;
@@ -11,44 +11,34 @@ Place = Y.Base.create('place', Y.Model, [Y.ModelSync.YQL], {
     cache      : new Y.CacheOffline(),
 
     queries: {
-        placeFromId    : 'SELECT {attrs} FROM geo.places WHERE woeid={id}',
-        placeFromText  : 'SELECT {attrs} FROM geo.places WHERE text="{text}"',
-        placeFromLatLon: 'SELECT {attrs} FROM geo.places WHERE woeid ' +
+        placeFromId    : 'SELECT * FROM geo.places WHERE woeid={id}',
+        placeFromLatLon: 'SELECT * FROM geo.places WHERE woeid ' +
                             'IN (SELECT place.woeid FROM flickr.places ' +
                             'WHERE api_key={api_key} ' +
                             'AND lat={latitude} ' +
                             'AND lon={longitude})'
     },
 
-    buildQuery: function (options) {
-        if (this.isNew()) {
-            if (options.text) {
-                return Lang.sub(this.queries.placeFromText, {
-                    text : options.text,
-                    attrs: Place.YQL_ATTRS
-                });
-            }
+    buildQuery: function () {
+        // one time initialization for FLICKR_API_KEY in lazy mode
+        FLICKR_API_KEY = FLICKR_API_KEY || YUI.namespace('Env.Flickr').API_KEY || '';
 
+        if (this.isNew()) {
             // assumes we at least have a lat/lon
             return Lang.sub(this.queries.placeFromLatLon, {
                 api_key  : FLICKR_API_KEY,
                 latitude : this.get('latitude'),
-                longitude: this.get('longitude'),
-                attrs    : Place.YQL_ATTRS
+                longitude: this.get('longitude')
             });
         }
 
-        return Lang.sub(this.queries.placeFromId, {
-            id   : this.get('id'),
-            attrs: Place.YQL_ATTRS
-        });
+        return Lang.sub(this.queries.placeFromId, {id: this.get('id')});
     },
 
     parse: function (results) {
-        if (!results) { return; }
+        if ( ! results) { return; }
 
-        var place    = results.place,
-            data     = Lang.isArray(place) ? place[0] : place,
+        var data     = results.place,
             centroid = data.centroid,
             country  = data.country,
             region   = data.admin1,
@@ -89,9 +79,7 @@ Place = Y.Base.create('place', Y.Model, [Y.ModelSync.YQL], {
         country  : {},
         region   : {},
         locality : {}
-    },
-
-    YQL_ATTRS: ['woeid', 'centroid', 'country', 'admin1', 'locality1']
+    }
 
 });
 

--- a/public/js/views/grid.js
+++ b/public/js/views/grid.js
@@ -85,7 +85,6 @@ Y.namespace('PNM').GridView = GridView;
     requires: [
         'node-style',
         'node-screen',
-        'pnm-photos',
         'pnm-templates',
         'view'
     ]

--- a/public/js/views/lightbox.js
+++ b/public/js/views/lightbox.js
@@ -101,7 +101,6 @@ Y.namespace('PNM').LightboxView = LightboxView;
 }, '0.5.0', {
     requires: [
         'event-key',
-        'pnm-photos',
         'pnm-templates',
         'transition',
         'view'


### PR DESCRIPTION
In case we want to set FLICKR_API_KEY right before calling new Y.App(), this fix the scenario in mojito where the attaching of the modules happens before defining YUI.namespace('Env.Flickr').API_KEY. In the future we might consider passing this key into the model as part of the initial configuration when creating the instance.
