### PR TITLE
Streamline uglify-js usage and add "minify templates" config

### DIFF
--- a/app.js
+++ b/app.js
@@ -95,7 +95,7 @@ app.get('/templates.js', (function () {
             layout   : false,
             templates: templates
         }, function (err, view) {
-            if (err) { return next(); }
+            if (err) { return req.next(); }
 
             res.send(uglify(view), {'Content-Type': 'application/javascript'}, 200);
         });

--- a/app.js
+++ b/app.js
@@ -189,7 +189,7 @@ app.get('/stats/', function (req, res) {
     res.json({
         uptime: process.uptime(),
         memory: process.memoryUsage()
-    })
+    });
 });
 
 // Catch-all route to dynamically figure out the place based on text.

--- a/app.js
+++ b/app.js
@@ -75,8 +75,7 @@ app.get('/combo', combo.combine({rootPath: pubDir + '/js'}), function (req, res)
 
 // Dymanic resource for precompiled templates.
 app.get('/templates.js', (function () {
-    var jsp = require('uglify-js').parser,
-        pro = require('uglify-js').uglify,
+    var uglify = require('uglify-js'),
 
         precompiled = require('./lib/templates').precompiled,
 
@@ -96,14 +95,7 @@ app.get('/templates.js', (function () {
         }, function (err, view) {
             if (err) { return next(); }
 
-            var ast = jsp.parse(view),
-                min;
-
-            min = pro.gen_code(
-                    pro.ast_squeeze(
-                        pro.ast_mangle(ast)));
-
-            res.send(min, {'Content-Type': 'application/javascript'}, 200);
+            res.send(uglify(view), {'Content-Type': 'application/javascript'}, 200);
         });
     };
 }()));

--- a/app.js
+++ b/app.js
@@ -49,6 +49,8 @@ app.configure('development', function () {
 });
 
 app.configure('production', function () {
+    // only minify templates in production
+    app.enable('uglify');
     app.enable('view cache');
     app.use(express.errorHandler());
 });
@@ -75,7 +77,7 @@ app.get('/combo', combo.combine({rootPath: pubDir + '/js'}), function (req, res)
 
 // Dymanic resource for precompiled templates.
 app.get('/templates.js', (function () {
-    var uglify = require('uglify-js'),
+    var uglify = app.enabled('uglify') ? require('uglify-js') : function (k) { return k; },
 
         precompiled = require('./lib/templates').precompiled,
 

--- a/app.js
+++ b/app.js
@@ -50,7 +50,7 @@ app.configure('development', function () {
 
 app.configure('production', function () {
     // only minify templates in production
-    app.enable('uglify');
+    app.enable('minify templates');
     app.enable('view cache');
     app.use(express.errorHandler());
 });
@@ -77,7 +77,7 @@ app.get('/combo', combo.combine({rootPath: pubDir + '/js'}), function (req, res)
 
 // Dymanic resource for precompiled templates.
 app.get('/templates.js', (function () {
-    var uglify = app.enabled('uglify') ? require('uglify-js') : function (k) { return k; },
+    var minify = app.enabled('minify templates') ? require('uglify-js') : function (k) { return k; },
 
         precompiled = require('./lib/templates').precompiled,
 
@@ -97,7 +97,7 @@ app.get('/templates.js', (function () {
         }, function (err, view) {
             if (err) { return req.next(); }
 
-            res.send(uglify(view), {'Content-Type': 'application/javascript'}, 200);
+            res.send(minify(view), {'Content-Type': 'application/javascript'}, 200);
         });
     };
 }()));


### PR DESCRIPTION
The method chaining in the initial implementation is handled automagically by the main `uglify-js` export, and makes the code read a little more clearer.

Also, it strikes me that minification should only be done in "production" environments, since it's rather hard to debug a problem in development with munged code. :)

The rest of the changes are sops to jshint (missing semicolon, incorrect `next()` call)
