### PR TITLE
Move client-side re-hydrating to Y.App subclass

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -122,6 +122,7 @@
                         "app-content",
                         "app-transitions",
                         "gallery-geo",
+                        "json-parse",
                         "pnm-grid-view",
                         "pnm-lightbox-view",
                         "pnm-no-location-view",

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -4,12 +4,21 @@ var PNM     = Y.PNM,
     PNMEnv  = YUI.namespace('Env.PNM'),
     PNMData = YUI.namespace('Env.PNM.DATA'),
 
-    Photo     = PNM.Photo,
-    Photos    = PNM.Photos,
-    Place     = PNM.Place,
+    Photo  = PNM.Photo,
+    Photos = PNM.Photos,
+    Place  = PNM.Place,
+
+    Helpers   = PNM.Helpers,
     Templates = PNM.Templates,
+
     PhotosNearMe;
 
+// Register template helpers.
+Y.Object.each(Helpers, function (helper, name) {
+    Y.Handlebars.registerHelper(name, helper);
+});
+
+// Define App.
 PhotosNearMe = Y.Base.create('photosNearMe', Y.App, [], {
 
     titleTemplate : Templates['title'],
@@ -215,7 +224,7 @@ PhotosNearMe = Y.Base.create('photosNearMe', Y.App, [], {
     },
 
     navigateToRoute: function (routeName, context, options) {
-        var path = Y.PNM.Helpers.pathTo(routeName, context);
+        var path = Helpers.pathTo(routeName, context);
         if (!path) { return false; }
         return this.navigate(path, options);
     },

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -52,14 +52,20 @@ PhotosNearMe = Y.Base.create('photosNearMe', Y.App, [], {
         this.on('lightboxView:next', this.navigateToPhoto);
     },
 
-    render: function () {
+    render: function (options) {
         PhotosNearMe.superclass.render.apply(this, arguments);
 
-        var place     = this.get('place'),
-            placeText = place.toString(),
-            container = this.get('container'),
-            doc       = Y.config.doc,
-            placeData, content;
+        options = (options || {});
+
+        var container, content, doc, place, placeData, placeText;
+
+        // No need to re-render the initial server rendering.
+        if (options.rendered) { return this; }
+
+        doc       = Y.config.doc;
+        container = this.get('container');
+        place     = this.get('place');
+        placeText = place.toString();
 
         placeData = place.isNew() ? null : {
             id  : place.get('id'),

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -37,18 +37,11 @@
     </script>
 
     <script>
-    YUI().use('pnm-app', 'json-parse', 'ios-oc-fix', function (Y) {
+    YUI().use('pnm-app', 'ios-oc-fix', function (Y) {
 
         var PNMEnv = YUI.namespace('Env.PNM'),
-            data   = YUI.namespace('Env.PNM.DATA'),
             routes = PNMEnv.ROUTES,
-            view   = PNMEnv.VIEW,
-            app, place, photos, photo;
-
-        // Re-hydrate models.
-        place  = new Y.PNM.Place(data.place ? Y.JSON.parse(data.place) : {});
-        photos = new Y.PNM.Photos({items: data.photos ? Y.JSON.parse(data.photos) : []});
-        photo  = new Y.PNM.Photo(data.photo ? Y.JSON.parse(data.photo) : {});
+            app;
 
         // Register template helpers.
         Y.Object.each(Y.PNM.Helpers, function (helper, name) {
@@ -57,9 +50,6 @@
 
         // Create app.
         app = new Y.PNM.App({
-            place : place,
-            photos: photos,
-
             container    : '#wrap',
             viewContainer: '#main',
 
@@ -73,34 +63,13 @@
             app.get('routes')[i].name = route.name;
         });
 
-        // Re-hydrate view.
-        if (view) {
-            app.showContent('#main .' + view.name, {
-                view: {
-                    name: view.name,
-
-                    config: {
-                        place : place,
-                        photos: photos,
-                        photo : photo
-                    }
-                },
-
-                transition: false
-            });
-        }
-
         // Determine if the user needs to be located. When the app is saved to
         // the home screen in iOS, always route to "/"" so geolocation lookup
         // is preformed.
-        if ((photo.isNew() && place.isNew()) || Y.config.win.navigator.standalone) {
+        if (Y.config.win.navigator.standalone) {
             app.locate();
         } else {
-            app.render();
-
-            if (photos.isEmpty()) {
-                app.loadPhotos();
-            }
+            app.render({rendered: true}).dispatch();
         }
 
     });

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -43,11 +43,6 @@
             routes = PNMEnv.ROUTES,
             app;
 
-        // Register template helpers.
-        Y.Object.each(Y.PNM.Helpers, function (helper, name) {
-            Y.Handlebars.registerHelper(name, helper);
-        });
-
         // Create app.
         app = new Y.PNM.App({
             container    : '#wrap',


### PR DESCRIPTION
This moves the re-hydrating process to the Y.App subclasses, removing the work the bootstrapping code has to do. This allows the app to be dispatched on initialization so it can follow its standard processes for handling a route, re-hydrating data as needed.
